### PR TITLE
incluir header do serverest de teste de carga

### DIFF
--- a/src/requests/login.request.js
+++ b/src/requests/login.request.js
@@ -9,6 +9,7 @@ export default class Login {
       headers: {
         'accept': 'application/json',
         'Content-Type': 'application/json',
+        'monitor': false,
       },
     };
   }

--- a/src/requests/products.request.js
+++ b/src/requests/products.request.js
@@ -9,6 +9,7 @@ export default class Products {
       headers: {
         'accept': 'application/json',
         'Content-Type': 'application/json',
+        'monitor': false,
       },
     };
   }

--- a/src/requests/users.request.js
+++ b/src/requests/users.request.js
@@ -8,6 +8,7 @@ export default class Users {
     this.params = {
       headers: {
         'Content-Type': 'application/json',
+        'monitor': false,
       },
     };
   }


### PR DESCRIPTION
O header `monitor: true` vai fazer com que as requests não sejam armazenadas na ferramenta de log utilizada pelo [ServeRest](https://github.com/ServeRest/ServeRest).

Com isso não há o risco de extrapolar o limite de 750.000 requests por mês e remover a visiblidade das requests em tempo real.